### PR TITLE
演奏会一覧をグリッド表示（横並び）にしてカード間の余白を確保

### DIFF
--- a/app/concerts/page.tsx
+++ b/app/concerts/page.tsx
@@ -54,14 +54,15 @@ export default function ConcertsPage() {
 							Concerts
 						</h1>
 
-						<div className="max-w-md mx-auto space-y-8">
+						<div className="mx-auto grid max-w-5xl grid-cols-1 gap-8 sm:grid-cols-2 xl:grid-cols-3">
 							{concerts.map((concert) => (
 								<Link
 									key={concert.id}
 									href={`/concerts/${concert.id}`}
 									aria-label={`${concert.title || "演奏会"}の詳細を見る`}
+									className="block h-full"
 								>
-									<div className="bg-white/10 backdrop-blur-md rounded-lg overflow-hidden hover:bg-white/20 hover:scale-[0.98] transition-all cursor-pointer">
+									<div className="flex h-full flex-col bg-white/10 backdrop-blur-md rounded-lg overflow-hidden hover:bg-white/20 hover:scale-[0.98] transition-all cursor-pointer">
 										<div className="p-5">
 											<div
 												className="relative w-full"


### PR DESCRIPTION
## 概要

演奏会一覧ページ（`/concerts`）のレイアウトを2点改善します。

1. 演奏会カードが縦1列に並んでいたのを、横並び（2〜3列）のグリッドに変更
2. カード間の隙間が潰れていた不具合を修正

## 変更前の状態

- `max-w-md` の1列 + `space-y-8` で縦積み
- `space-y-*` は隣接要素の `margin-top` で余白を作る仕組みだが、`Link`（`<a>`＝インライン要素）に対しては効きにくく、カード間の隙間がほぼ無い状態になっていた

## 対応

- コンテナを `grid` レイアウトに変更
  - `grid-cols-1`（モバイル） / `sm:grid-cols-2`（2列） / `xl:grid-cols-3`（3列）
  - `gap-8` でカード間の縦横の余白を確保（gridなのでインライン要素問題も解消）
  - `max-w-5xl` に広げて横並びのスペースを確保
- 各カードを `h-full flex flex-col` にし、同じ行のカード高さが揃うように調整

## テスト

- `npx tsc --noEmit`： 通過
- `npx jest`： 全17件パス（`concerts/page.test.tsx` 含む）
- `next build`： 成功

見た目はプレビュー環境でご確認ください。演奏会の件数に応じて 1〜3 列で表示されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)