### PR TITLE
Coming Soon プレースホルダーを簡素化（音符・日本語・二重枠を削除）

### DIFF
--- a/public/coming-soon-poster.svg
+++ b/public/coming-soon-poster.svg
@@ -5,29 +5,8 @@
   <!-- 枠線 -->
   <rect x="50" y="50" width="2794" height="3993" stroke="#9CA3AF" stroke-width="4" fill="none" stroke-dasharray="20 10"/>
 
-  <!-- タイトル領域の背景 -->
-  <rect x="200" y="1800" width="2494" height="500" fill="#D1D5DB" fill-opacity="0.5" rx="20"/>
-
   <!-- "Coming Soon..." テキスト -->
-  <text x="1447" y="2050" font-family="Arial, sans-serif" font-size="180" font-weight="300" fill="#6B7280" text-anchor="middle" opacity="0.8">
+  <text x="1447" y="2110" font-family="Arial, sans-serif" font-size="180" font-weight="300" fill="#6B7280" text-anchor="middle" opacity="0.8">
     Coming Soon...
-  </text>
-
-  <!-- 装飾的な音符記号 -->
-  <text x="1447" y="1500" font-family="serif" font-size="300" fill="#9CA3AF" text-anchor="middle" opacity="0.3">
-    ♪
-  </text>
-
-  <text x="800" y="2800" font-family="serif" font-size="200" fill="#9CA3AF" text-anchor="middle" opacity="0.2">
-    ♫
-  </text>
-
-  <text x="2100" y="2900" font-family="serif" font-size="250" fill="#9CA3AF" text-anchor="middle" opacity="0.2">
-    ♩
-  </text>
-
-  <!-- 下部の説明テキスト -->
-  <text x="1447" y="2600" font-family="Arial, sans-serif" font-size="80" font-weight="400" fill="#6B7280" text-anchor="middle" opacity="0.6">
-    詳細は後日発表いたします
   </text>
 </svg>


### PR DESCRIPTION
## 概要

演奏会のポスターが未定のときに表示されるプレースホルダー（`public/coming-soon-poster.svg`）の見た目を簡素化します。

トップページの「Upcoming Concert」や演奏会詳細ページで、ポスター画像がない演奏会に対して表示されるものです。

## 変更内容

以下を削除し、点線枠の中央に「Coming Soon...」のみを表示するようにしました。

- 装飾の音符記号（♪ ♫ ♩）
- 日本語の説明文「詳細は後日発表いたします」
- 「Coming Soon...」背後の内側の灰色ボックス（点線枠と二重の囲いになっていたため）

「Coming Soon...」は縦中央に配置し直しています。

## 確認

SVGのみの変更です。ビルドや型への影響はありません。デプロイ後、トップページの「Upcoming Concert」でプレビューをご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)