### PR TITLE
dev → main: Coming Soon プレースホルダー簡素化 & CLAUDE.md 追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# folle-web 開発ルール
+
+Orchestra più Folle の Web サイト（Next.js）のリポジトリ。
+
+## ブランチ運用（最重要）
+
+- feature / fix ブランチのマージは必ず dev を経由し、`feature → dev → main` の順で進める。
+- feature / fix ブランチを main に直接マージしてはいけない。
+- 新しい feature / fix ブランチの PR は base を `main` ではなく `dev` にする。
+- dev に溜まった変更は、別途 dev → main の PR でリリースする。
+- main への直接コミット・プッシュは禁止。
+- dev と main が乖離した場合は dev を main に同期する（両者が ancestor 関係なら `git merge --ff-only origin/main`）。
+
+## デプロイ
+
+- ライブサイト（piufolle.com）は main ブランチをデプロイしている。
+- したがって、ライブに反映したい変更は最終的に dev → main のマージまで進める必要がある。
+
+## 進行中ブランチ
+
+- `feature/loading-green-background` は進行中のため削除しない。
+
+## お問い合わせフォームのメール送信
+
+- お問い合わせはデータベースに保存せず、nodemailer + Gmail SMTP でメール送信する。
+- 実送信には環境変数 `EMAIL_ADDRESS` / `EMAIL_PASSWORD` が必要。受信先は `CONTACT_TO_EMAIL`（未設定時は `EMAIL_ADDRESS` 宛）。
+- ローカル / プレビューでは `CONTACT_DRY_RUN=1` で実送信をスキップできる。

--- a/public/coming-soon-poster.svg
+++ b/public/coming-soon-poster.svg
@@ -5,29 +5,8 @@
   <!-- 枠線 -->
   <rect x="50" y="50" width="2794" height="3993" stroke="#9CA3AF" stroke-width="4" fill="none" stroke-dasharray="20 10"/>
 
-  <!-- タイトル領域の背景 -->
-  <rect x="200" y="1800" width="2494" height="500" fill="#D1D5DB" fill-opacity="0.5" rx="20"/>
-
   <!-- "Coming Soon..." テキスト -->
-  <text x="1447" y="2050" font-family="Arial, sans-serif" font-size="180" font-weight="300" fill="#6B7280" text-anchor="middle" opacity="0.8">
+  <text x="1447" y="2110" font-family="Arial, sans-serif" font-size="180" font-weight="300" fill="#6B7280" text-anchor="middle" opacity="0.8">
     Coming Soon...
-  </text>
-
-  <!-- 装飾的な音符記号 -->
-  <text x="1447" y="1500" font-family="serif" font-size="300" fill="#9CA3AF" text-anchor="middle" opacity="0.3">
-    ♪
-  </text>
-
-  <text x="800" y="2800" font-family="serif" font-size="200" fill="#9CA3AF" text-anchor="middle" opacity="0.2">
-    ♫
-  </text>
-
-  <text x="2100" y="2900" font-family="serif" font-size="250" fill="#9CA3AF" text-anchor="middle" opacity="0.2">
-    ♩
-  </text>
-
-  <!-- 下部の説明テキスト -->
-  <text x="1447" y="2600" font-family="Arial, sans-serif" font-size="80" font-weight="400" fill="#6B7280" text-anchor="middle" opacity="0.6">
-    詳細は後日発表いたします
   </text>
 </svg>


### PR DESCRIPTION
## 概要

dev に溜まった以下の変更を main へリリースします。

- #49 Coming Soon プレースホルダーの音符・日本語・二重の灰色枠を削除
- #50 CLAUDE.md 追加（ブランチ運用ルール `feature → dev → main` を明記）

ライブサイト（piufolle.com）は main をデプロイしているため、このマージで反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)