### PR TITLE
第2回演奏会の説明文を「未定」に変更

### DIFF
--- a/lib/constants/concerts.ts
+++ b/lib/constants/concerts.ts
@@ -107,8 +107,7 @@ export const CONCERTS: Concert[] = [
 		},
 		ticketPrice: [],
 		teketUrl: null,
-		description:
-			"Orchestra più Folle 第2回演奏会を開催いたします。詳細は後日発表いたします。",
+		description: "未定",
 	},
 ];
 


### PR DESCRIPTION
## 概要

第2回演奏会の説明文（`lib/constants/concerts.ts`）を「未定」に変更します。

- 変更前: 「Orchestra più Folle 第2回演奏会を開催いたします。詳細は後日発表いたします。」
- 変更後: 「未定」

base は `dev`（ルール通り）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)