### PR TITLE
dev → main: ローディング文字フォント(DIN系)拡大 & 第2回説明文を未定に

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -253,6 +253,13 @@
 .text {
 	display: inline-block;
 	opacity: 0;
+	/* next/font でセルフホストした Archivo(--font-din) を全端末で使用。
+	   DIN Alternate に近い標準幅グロテスク。以降は保険のフォールバック */
+	font-family: var(--font-din), "DIN Alternate", "Bahnschrift", "Helvetica Neue",
+		Arial, sans-serif;
+	letter-spacing: 0.06em;
+	font-size: clamp(1.75rem, 4vw, 2.5rem);
+	font-weight: 700;
 }
 
 .logo {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
-import { roboto, inter } from "@/app/ui/fonts";
+import { roboto, inter, archivo } from "@/app/ui/fonts";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/next";
 
@@ -55,7 +55,10 @@ export default function RootLayout({
 	children: React.ReactNode;
 }) {
 	return (
-		<html lang="ja" className={`${roboto.variable} ${inter.variable}`}>
+		<html
+			lang="ja"
+			className={`${roboto.variable} ${inter.variable} ${archivo.variable}`}
+		>
 			<head>
 				<link rel="icon" href="/logo.png" />
 			</head>

--- a/app/ui/fonts.ts
+++ b/app/ui/fonts.ts
@@ -1,4 +1,14 @@
-import { Roboto, Inter } from "next/font/google";
+import { Roboto, Inter, Archivo_Narrow } from "next/font/google";
+
+// ローディングの "Orchestra più Folle" 用。DIN Alternate に近い縦長のナロー体。
+// next/font がセルフホストするため全端末で同一表示になる。
+export const archivo = Archivo_Narrow({
+	subsets: ["latin"],
+	weight: ["500", "600", "700"],
+	display: "swap",
+	variable: "--font-din",
+	fallback: ["DIN Alternate", "DIN Condensed", "Bahnschrift", "Arial", "sans-serif"],
+});
 
 export const roboto = Roboto({
 	subsets: ["latin"],

--- a/lib/constants/concerts.ts
+++ b/lib/constants/concerts.ts
@@ -107,8 +107,7 @@ export const CONCERTS: Concert[] = [
 		},
 		ticketPrice: [],
 		teketUrl: null,
-		description:
-			"Orchestra più Folle 第2回演奏会を開催いたします。詳細は後日発表いたします。",
+		description: "未定",
 	},
 ];
 


### PR DESCRIPTION
## 概要

dev に溜まった以下の変更を main へリリースします。

- #52 ローディングの「Orchestra più Folle」を Archivo Narrow（DIN Alternate 系のナロー体）に変更＋文字サイズ拡大。next/font でセルフホストし全端末で同一表示
- #53 第2回演奏会の説明文を「未定」に変更

ライブサイト（piufolle.com）は main をデプロイしているため、このマージで反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)