### PR TITLE
AboutテストからHistoryセクションのテストを除去（CI修復）

### DIFF
--- a/__tests__/app/about/page.test.tsx
+++ b/__tests__/app/about/page.test.tsx
@@ -17,23 +17,6 @@ describe("About Page", () => {
 		expect(introText).toBeInTheDocument();
 	});
 
-	it("renders history section", async () => {
-		render(await AboutPage());
-
-		// 沿革セクションの見出しが表示されているか確認
-		expect(
-			screen.getByRole("heading", { name: /History/i })
-		).toBeInTheDocument();
-
-		// 設立年の表示確認
-		const yearElements = screen.getAllByText("2025");
-		expect(yearElements.length).toBeGreaterThan(0);
-
-		// イベントの表示確認
-		expect(screen.getByText("Orchestra più Folle 設立")).toBeInTheDocument();
-		expect(screen.getByText("第1回特別演奏会開催予定")).toBeInTheDocument();
-	});
-
 	it("renders logo and description", async () => {
 		render(await AboutPage());
 


### PR DESCRIPTION
## 概要

先の About ページ整理（#55）で History セクションを削除したことにより、`__tests__/app/about/page.test.tsx` の "renders history section" テストが失敗し、main の CI（test）が落ちていました。

不要になったこのテストを削除して CI を修復します。

## 確認

- `npx jest`: 全パス（History テスト削除後）

なお Vercel デプロイ自体は成功しています（今回は GitHub Actions の test ジョブのみの失敗でした）。

base は `dev`（ルール通り）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)