### PR TITLE
リリース: スマホ下部の白背景修正

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -109,8 +109,19 @@
 		cursor: not-allowed;
 	}
 
+	/*
+	 * 固定背景画像(/bg-green.jpg)がモバイルのアドレスバー可変分などで
+	 * 覆いきれない領域が出ても白くならないよう、下地を暗い緑基調にする。
+	 */
+	html {
+		background-color: #0e1a13;
+	}
+
 	body {
-		@apply bg-[hsl(var(--background))] text-[hsl(var(--foreground))];
+		@apply text-[hsl(var(--foreground))];
+		background-color: #0e1a13;
+		/* ページ全体を覆う固定背景(absolute inset-0)の位置基準にする */
+		position: relative;
 		font-family: "Roboto", sans-serif; /* var(--font-roboto)より直接指定を推奨 */
 		line-height: 1.8;
 		overscroll-behavior-x: auto;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -65,8 +65,9 @@ export default function RootLayout({
 				<link rel="icon" href="/logo.png" />
 			</head>
 			<body className="font-sans antialiased min-h-screen flex flex-col">
-				{/* 遷移中に一瞬白くならないよう、背景画像をレイアウト側に常設 */}
-				<div className="fixed inset-0 -z-10">
+				{/* 遷移中に一瞬白くならないよう、背景画像をレイアウト側に常設。
+				    ページ全体(絶対配置)を覆うことでモバイルでも下部が白くならない。 */}
+				<div className="absolute inset-0 -z-10">
 					<Image
 						src="/bg-green.jpg"
 						alt=""


### PR DESCRIPTION
## 概要

dev の変更（PR #61）を main へリリースします。

## 含まれる変更

- スマホ表示でページ下部が白くなる問題を修正
  - 固定背景を `fixed` → `absolute inset-0`（ページ全体基準）に変更
  - html / body の下地色を暗い緑基調（#0e1a13）に設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)