### PR TITLE
リリース: ボタンのデザイン・ホバー刷新

### DIFF
--- a/app/concerts/[id]/page.tsx
+++ b/app/concerts/[id]/page.tsx
@@ -240,8 +240,8 @@ export default function ConcertDetailPage() {
 														aria-label="Teketで演奏会のチケットを予約する（新しいタブで開きます）"
 													>
 														<Button
-															variant="outline"
-															className="w-full bg-[hsl(var(--primary))] hover:brightness-110 text-[hsl(var(--primary-foreground))] border-0 relative py-3 group flex items-center gap-0"
+															size="lg"
+															className="w-full py-3 group flex items-center gap-0"
 														>
 															<div className="w-[108px] h-[42px] relative">
 																<Image
@@ -258,8 +258,8 @@ export default function ConcertDetailPage() {
 												) : (
 													<div className="relative group">
 														<Button
-															variant="outline"
-															className="w-full bg-[hsl(var(--primary))] hover:brightness-105 text-[hsl(var(--primary-foreground))] border-0 cursor-not-allowed opacity-80 relative py-3 group flex items-center gap-0"
+															size="lg"
+															className="w-full py-3 group flex items-center gap-0 cursor-not-allowed opacity-80"
 															disabled
 															aria-label="チケット予約は近日公開予定です"
 														>

--- a/app/concerts/[id]/page.tsx
+++ b/app/concerts/[id]/page.tsx
@@ -241,7 +241,7 @@ export default function ConcertDetailPage() {
 													>
 														<Button
 															size="lg"
-															className="w-full py-3 group flex items-center gap-0"
+															className="w-full max-w-sm group gap-0"
 														>
 															<div className="w-[108px] h-[42px] relative">
 																<Image
@@ -256,10 +256,10 @@ export default function ConcertDetailPage() {
 														</Button>
 													</a>
 												) : (
-													<div className="relative group">
+													<div className="relative group flex justify-center">
 														<Button
 															size="lg"
-															className="w-full py-3 group flex items-center gap-0 cursor-not-allowed opacity-80"
+															className="w-full max-w-sm group gap-0 cursor-not-allowed opacity-80"
 															disabled
 															aria-label="チケット予約は近日公開予定です"
 														>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -369,8 +369,9 @@ export default function ContactPage() {
 									<div className="text-center">
 										<Button
 											type="submit"
+											size="lg"
 											disabled={isSubmitting}
-											className="px-8 py-3"
+											className="min-w-[12rem] tracking-widest"
 										>
 											{isSubmitting ? "送信中..." : "送信"}
 										</Button>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -366,12 +366,12 @@ export default function ContactPage() {
 										)}
 									</div>
 
-									<div className="text-center">
+									<div className="flex justify-center">
 										<Button
 											type="submit"
 											size="lg"
 											disabled={isSubmitting}
-											className="min-w-[12rem] tracking-widest"
+											className="w-full max-w-sm tracking-widest"
 										>
 											{isSubmitting ? "送信中..." : "送信"}
 										</Button>

--- a/app/news/[id]/page.tsx
+++ b/app/news/[id]/page.tsx
@@ -69,7 +69,6 @@ export default function NewsDetailPage() {
 							<Button
 								onClick={() => router.push("/")}
 								variant="outline"
-								className="border-0 bg-white/5 text-white ring-1 ring-white/15 transition-all hover:bg-[hsl(var(--brand)/0.2)] hover:ring-[hsl(var(--brand)/0.5)]"
 							>
 								ホームに戻る
 							</Button>
@@ -92,7 +91,7 @@ export default function NewsDetailPage() {
 								<Button
 									onClick={() => router.back()}
 									variant="outline"
-									className="border-0 bg-white/5 text-white ring-1 ring-white/15 transition-all hover:bg-[hsl(var(--brand)/0.2)] hover:ring-[hsl(var(--brand)/0.5)] flex items-center gap-2"
+									className="flex items-center gap-2"
 								>
 									<svg
 										width="16"
@@ -177,7 +176,7 @@ export default function NewsDetailPage() {
 												>
 													<Button
 														variant="outline"
-														className="w-full border-0 bg-white/5 text-white ring-1 ring-white/15 transition-all hover:bg-[hsl(var(--brand)/0.2)] hover:ring-[hsl(var(--brand)/0.5)] justify-start text-left h-auto py-3 px-4"
+														className="w-full justify-start text-left h-auto py-3 px-4"
 														style={{
 															wordBreak: "break-all",
 															overflowWrap: "anywhere",

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,26 +5,26 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-medium transition-all duration-300 ease-out will-change-transform hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50 disabled:translate-y-0 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-[hsl(var(--brand)/0.5)] focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] shadow-md shadow-black/25 hover:brightness-110 hover:shadow-lg hover:shadow-[hsl(var(--brand)/0.45)]",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white shadow-md shadow-black/25 hover:brightness-110 hover:shadow-lg focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-white/20 bg-white/5 text-white backdrop-blur-sm shadow-sm shadow-black/20 hover:border-[hsl(var(--brand)/0.6)] hover:bg-[hsl(var(--brand)/0.15)] hover:shadow-lg hover:shadow-black/30",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground shadow-md shadow-black/25 hover:brightness-110 hover:shadow-lg",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "text-white hover:bg-white/10 hover:-translate-y-0 active:scale-100",
+        link: "text-[hsl(var(--primary))] underline-offset-4 hover:underline hover:-translate-y-0 active:scale-100",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        default: "h-10 px-5 py-2 has-[>svg]:px-4",
+        sm: "h-8 rounded-lg gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-12 rounded-xl px-8 text-base has-[>svg]:px-6",
         icon: "size-9",
       },
     },

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -11,11 +11,11 @@ const buttonVariants = cva(
       // 通常は白枠+透明、ホバーで左から緑が埋まる（背景を左基準で 0%→100% に拡大）
       variant: {
         default:
-          "border border-white/80 text-white bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:border-[hsl(var(--brand))]",
+          "border border-[hsl(var(--brand))] text-[hsl(var(--brand))] bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:text-white",
         destructive:
           "bg-destructive text-white hover:brightness-110 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border border-white/50 text-white bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:border-[hsl(var(--brand))]",
+          "border border-[hsl(var(--brand))] text-[hsl(var(--brand))] bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:text-white",
         secondary:
           "bg-secondary text-secondary-foreground hover:brightness-110",
         ghost: "text-white hover:bg-white/10",

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,27 +5,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-medium transition-all duration-300 ease-out will-change-transform hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50 disabled:translate-y-0 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-[hsl(var(--brand)/0.5)] focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-none text-sm font-medium transition-all duration-300 ease-out active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-[hsl(var(--brand)/0.5)] focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
+      // 通常は白枠+透明、ホバーで左から緑が埋まる（背景を左基準で 0%→100% に拡大）
       variant: {
         default:
-          "bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] shadow-md shadow-black/25 hover:brightness-110 hover:shadow-lg hover:shadow-[hsl(var(--brand)/0.45)]",
+          "border border-white/80 text-white bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:border-[hsl(var(--brand))]",
         destructive:
-          "bg-destructive text-white shadow-md shadow-black/25 hover:brightness-110 hover:shadow-lg focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white hover:brightness-110 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border border-white/20 bg-white/5 text-white backdrop-blur-sm shadow-sm shadow-black/20 hover:border-[hsl(var(--brand)/0.6)] hover:bg-[hsl(var(--brand)/0.15)] hover:shadow-lg hover:shadow-black/30",
+          "border border-white/50 text-white bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:border-[hsl(var(--brand))]",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-md shadow-black/25 hover:brightness-110 hover:shadow-lg",
-        ghost:
-          "text-white hover:bg-white/10 hover:-translate-y-0 active:scale-100",
-        link: "text-[hsl(var(--primary))] underline-offset-4 hover:underline hover:-translate-y-0 active:scale-100",
+          "bg-secondary text-secondary-foreground hover:brightness-110",
+        ghost: "text-white hover:bg-white/10",
+        link: "text-[hsl(var(--primary))] underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-5 py-2 has-[>svg]:px-4",
-        sm: "h-8 rounded-lg gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-12 rounded-xl px-8 text-base has-[>svg]:px-6",
-        icon: "size-9",
+        default: "h-12 px-6 py-2 has-[>svg]:px-4",
+        sm: "h-10 gap-1.5 px-4 has-[>svg]:px-3",
+        lg: "h-14 px-8 text-base has-[>svg]:px-6",
+        icon: "size-11",
       },
     },
     defaultVariants: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -11,11 +11,11 @@ const buttonVariants = cva(
       // 通常は白枠+透明、ホバーで左から緑が埋まる（背景を左基準で 0%→100% に拡大）
       variant: {
         default:
-          "border border-[hsl(var(--brand))] text-[hsl(var(--brand))] bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:text-white",
+          "border border-white/80 text-white bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:border-[hsl(var(--brand))]",
         destructive:
           "bg-destructive text-white hover:brightness-110 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border border-[hsl(var(--brand))] text-[hsl(var(--brand))] bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:text-white",
+          "border border-white/50 text-white bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand))] bg-left bg-no-repeat bg-[length:0%_100%] hover:bg-[length:100%_100%] hover:border-[hsl(var(--brand))]",
         secondary:
           "bg-secondary text-secondary-foreground hover:brightness-110",
         ghost: "text-white hover:bg-white/10",


### PR DESCRIPTION
## 概要

dev の変更（PR #69）を main へリリースします。

- ボタンを白枠＋白文字、ホバーで左から緑が埋まる outarc 風の挙動に刷新
- 角丸なし・高さアップ・グロー廃止
- teket 予約ボタンと送信ボタンの幅を統一（w-full max-w-sm 中央寄せ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)