### PR TITLE
ci: 18:00 JSTにdev→mainを自動反映するワークフローを追加

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -1,0 +1,43 @@
+name: Scheduled Release (dev to main)
+
+# 2026-07-11 18:00 JST (= 09:00 UTC) に dev を main へ反映するための一度きりのワークフロー。
+# 実行日を過ぎたら自己削除して再実行を防ぐ。手動実行(workflow_dispatch)も可能。
+
+on:
+  schedule:
+    - cron: "0 9 * * *" # 09:00 UTC = 18:00 JST
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge dev into main (release)
+        run: |
+          set -euo pipefail
+          # スケジュール実行は反映日(JST 2026-07-11 = UTC 2026-07-11)のみ実施。
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "$(date -u +%F)" != "2026-07-11" ]; then
+            echo "本日は反映日ではないためスキップ (UTC $(date -u +%F))"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main dev
+          git checkout main
+          # dev を main へマージ（コンフリクト時は set -e で失敗し反映しない）
+          git merge --no-ff origin/dev -m "リリース: dev を main へ反映 (自動 18:00 JST)"
+          # 一度きりのため、このワークフロー自身を削除して以後の実行を止める
+          git rm .github/workflows/scheduled-release.yml
+          git commit -m "chore: 一度きりのリリース用ワークフローを削除"
+          git push origin main


### PR DESCRIPTION
## 概要
本日 2026-07-11 18:00 JST に dev を main へ自動反映するための一度きりの GitHub Actions ワークフローを追加します。

- スケジュール: `0 9 * * *`（09:00 UTC = 18:00 JST）
- 反映日(2026-07-11 UTC)以外はスキップ
- 実行後はワークフロー自身を削除し、再実行を防止
- 手動実行(workflow_dispatch)も可能

このPRは CI 設定の追加のみで、サイト本体の変更は含みません（本体は 18:00 のスケジュール実行で反映）。スケジュール実行はデフォルトブランチ(main)上のワークフローである必要があるため、先に main へ入れます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)