### PR TITLE
fix: 詳細ページのないニュースはホバーで緑にしない

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -303,7 +303,7 @@ export default function HomePage() {
 														<span className="font-mono text-sm text-white/60">
 															{item.date}
 														</span>
-														<h3 className="text-white transition-colors group-hover:text-[hsl(var(--brand))]">
+														<h3 className={`text-white transition-colors ${item.hasDetailPage ? "group-hover:text-[hsl(var(--brand))]" : ""}`}>
 															{item.title}
 														</h3>
 													</div>


### PR DESCRIPTION
詳細ページを持たないニュース項目は、ホバー時にタイトルが緑（ブランドカラー）にならないようにしました（クリックできない項目にホバー装飾が出るのを防止）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)