### PR TITLE
test: Aboutテストの期待文言を(Fオケ)削除後に修正

### DIFF
--- a/__tests__/app/about/page.test.tsx
+++ b/__tests__/app/about/page.test.tsx
@@ -12,7 +12,7 @@ describe("About Page", () => {
 
 		// 団体紹介のテキストが表示されているか確認
 		const introText = screen.getByText((content) =>
-			content.includes("Orchestra più Folle (Fオケ)")
+			content.includes("Orchestra più Folle")
 		);
 		expect(introText).toBeInTheDocument();
 	});


### PR DESCRIPTION
「(Fオケ)」削除により About ページの Test が失敗していたため、期待文字列を `Orchestra più Folle` に更新しました。ローカルで全17テスト通過を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)