### PR TITLE
fix: 演奏会詳細で「Concert not found」が一瞬ちらつく問題を解消

### DIFF
--- a/app/concerts/[id]/page.tsx
+++ b/app/concerts/[id]/page.tsx
@@ -16,7 +16,16 @@ export default function ConcertDetailPage() {
 	// データは静的な定数のため同期的に取得する。
 	// クライアント専用の loading ゲートに依存すると、hydration に失敗した際に
 	// 「Loading...」のまま固まることがあるため、サーバ/クライアント両方で描画する。
-	const concert = getConcert(params.id as string);
+	const rawId = params?.id;
+	const id = Array.isArray(rawId) ? rawId[0] : rawId;
+	const concert = id ? getConcert(id) : null;
+
+	// ルートパラメータが未解決の瞬間は「not found」を出さず、背景のみ表示する
+	// （useParams が一瞬 id を返さないケースで「Concert not found」が
+	//   一瞬ちらつくのを防ぐ）
+	if (!id) {
+		return <div className="min-h-screen" aria-hidden="true" />;
+	}
 
 	if (!concert) {
 		return (


### PR DESCRIPTION
## 原因
`useParams()` の `id` が一瞬未解決(`undefined`)になる瞬間があり、その間 `getConcert(undefined)` が `null` を返して「Concert not found」が一瞬表示されていました。

## 修正
- `id` が未解決の間は not found を出さず背景のみ表示。
- `id` があって該当演奏会が無い場合のみ「Concert not found」を表示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)