### PR TITLE
fix: タブレット縦のレイアウト崩れを解消（2カラム/フルナビをlg以上に）

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -225,12 +225,12 @@ export default function HomePage() {
 
 				{/* Content Container（背景はレイアウトの固定背景を使用）。オープニング中は非表示 */}
 				<div
-					className={`relative z-10 flex flex-col md:flex-row md:items-start pt-20 pb-10 ${
+					className={`relative z-10 flex flex-col lg:flex-row lg:items-start pt-20 pb-10 ${
 						showOverlay ? "invisible" : "content-reveal"
 					}`}
 				>
 					{/* Main Content */}
-					<div className="w-full md:flex-1 md:min-w-0">
+					<div className="w-full lg:flex-1 lg:min-w-0">
 						{/* Logo and News Container */}
 						<div className="relative flex flex-col">
 							{/* 演奏風景の写真（左右に均等な余白を持たせ、Welcome表記付き） */}
@@ -380,9 +380,9 @@ export default function HomePage() {
 					</div>
 
 					{/* Right Side - 次回 / 直近の演奏会 */}
-					<div className="w-full md:w-auto md:shrink-0 pl-6 pr-6 md:pr-14 py-8 flex items-start justify-center mt-8 md:mt-0">
+					<div className="w-full lg:w-auto lg:shrink-0 pl-6 pr-6 lg:pr-14 py-8 flex items-start justify-center mt-8 lg:mt-0">
 						{featuredConcert && (
-							<div className="w-full md:w-[calc((100vh-220px)*0.707)] flex flex-col">
+							<div className="w-full lg:w-[calc((100vh-220px)*0.707)] flex flex-col">
 								<h2 className="mb-6 text-2xl font-bold tracking-tight text-white">
 									{featuredLabel}
 								</h2>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -90,7 +90,7 @@ export default function Header() {
 
 						{/* Desktop Navigation */}
 						<nav
-							className="max-md:hidden flex items-center space-x-8"
+							className="max-lg:hidden flex items-center space-x-8"
 							aria-label="メインナビゲーション"
 						>
 							{navItems.map((item) => (
@@ -106,7 +106,7 @@ export default function Header() {
 
 						{/* Mobile Menu Button */}
 						<button
-							className="md:hidden p-2 text-white hover:text-[hsl(var(--primary))] hover:brightness-150 transition-colors duration-200"
+							className="lg:hidden p-2 text-white hover:text-[hsl(var(--primary))] hover:brightness-150 transition-colors duration-200"
 							onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
 							aria-label="メインメニューを開閉"
 							aria-expanded={isMobileMenuOpen}
@@ -119,7 +119,7 @@ export default function Header() {
 					{/* Mobile Navigation */}
 					<nav
 						id="mobile-navigation"
-						className={`md:hidden mt-4 pb-4 border-t border-black/10 ${
+						className={`lg:hidden mt-4 pb-4 border-t border-black/10 ${
 							!isMobileMenuOpen ? "hidden" : ""
 						}`}
 						aria-label="モバイルメインナビゲーション"


### PR DESCRIPTION
## 概要
iPad 縦などタブレット縦表示でホームの2カラムが崩れる問題を修正し、ヘッダーもタブレット縦ではモバイルと同じハンバーガー메뉴にします。

## 変更
- ホーム: 2カラム化の分岐を `md`(768px)→`lg`(1024px)に。タブレット縦では縦積み表示。
- ヘッダー: フルナビ/ハンバーガーの切替を `md`→`lg`に。タブレット縦でもハンバーガー表示。

## 背景
チラシ列の幅が `calc((100vh-220px)*0.707)` で縦長画面ほど広くなり、md分岐だとタブレット縦で左カラムが潰れていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)