### PR TITLE
fix: 演奏会詳細のタブレット時チラシ幅を抑え、タイトルをチラシ上部へ

### DIFF
--- a/app/concerts/[id]/page.tsx
+++ b/app/concerts/[id]/page.tsx
@@ -132,6 +132,10 @@ export default function ConcertDetailPage() {
 									</svg>
 									演奏会一覧へ戻る
 								</Link>
+								{/* タイトル（全端末でチラシの上に配置） */}
+								<h1 className="mb-6 text-2xl font-bold text-white break-words">
+									{concert.title}
+								</h1>
 								<div className="flex flex-col gap-8 lg:flex-row lg:gap-14">
 										{/* ポスター画像（表裏が揃う場合はクリックでめくって切替） */}
 										<FlyerFlip
@@ -142,9 +146,6 @@ export default function ConcertDetailPage() {
 
 										{/* コンサート情報 */}
 										<div className="flex-1">
-											<h1 className="text-xl font-bold text-white mb-6 break-words">
-												{concert.title}
-											</h1>
 											<div className="space-y-4 text-white/90 mb-8">
 												<div className="space-y-1">
 													<div className="flex flex-wrap items-baseline gap-x-3">

--- a/components/ui/flyer-flip.tsx
+++ b/components/ui/flyer-flip.tsx
@@ -28,7 +28,7 @@ export function FlyerFlip({ front, back, title }: FlyerFlipProps) {
 		return (
 			<div className="w-full lg:w-auto shrink-0">
 				<div
-					className="relative mx-auto w-full overflow-hidden rounded-2xl shadow-2xl shadow-black/50 ring-1 ring-white/10 lg:w-[360px]"
+					className="relative mx-auto w-full max-w-[320px] overflow-hidden rounded-2xl shadow-2xl shadow-black/50 ring-1 ring-white/10 lg:max-w-none lg:w-[360px]"
 					style={{ aspectRatio: "0.707" }}
 				>
 					<Image
@@ -52,7 +52,7 @@ export function FlyerFlip({ front, back, title }: FlyerFlipProps) {
 				type="button"
 				onClick={() => setFlipped((prev) => !prev)}
 				aria-label={flipped ? "チラシの表面を表示" : "チラシの裏面を表示"}
-				className="group relative mx-auto block w-full cursor-pointer rounded-2xl [perspective:1800px] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 lg:w-[360px]"
+				className="group relative mx-auto block w-full max-w-[320px] cursor-pointer rounded-2xl [perspective:1800px] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 lg:max-w-none lg:w-[360px]"
 				style={{ aspectRatio: "0.707" }}
 			>
 				<div


### PR DESCRIPTION
- タブレット縦でチラシ(ポスター)が大きすぎたため、lg未満で max-w-[320px] に制限（lg以上は360px）。
- 演奏会タイトルを情報カラム内から、全端末でチラシの上（コンテンツ先頭）に移動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)