### PR TITLE
fix: ニュース詳細から戻る際の「ニュースが見つかりません」ちらつきを解消

### DIFF
--- a/app/news/[id]/page.tsx
+++ b/app/news/[id]/page.tsx
@@ -16,13 +16,13 @@ export default function NewsDetailPage() {
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
-		const fetchNewsItem = async () => {
-			const item = getNewsById(params.id as string);
-			setNewsItem(item);
-			setIsLoading(false);
-		};
-
-		fetchNewsItem();
+		const rawId = params?.id;
+		const id = Array.isArray(rawId) ? rawId[0] : rawId;
+		// ルートパラメータが未解決（戻る操作の遷移アニメ中など）の間は状態を変えず、
+		// 直前のニュースを保持して「ニュースが見つかりません」のちらつきを防ぐ
+		if (!id) return;
+		setNewsItem(getNewsById(id));
+		setIsLoading(false);
 	}, [params.id]);
 
 	if (isLoading) {


### PR DESCRIPTION
## 原因
戻る操作の遷移アニメ中に `useParams()` の `id` が一瞬未解決(`undefined`)になり、`getNewsById(undefined)` が `null` を返して「ニュースが見つかりません」が一瞬表示されていました。

## 修正
`id` が未解決の間は state を更新せず直前のニュースを保持。`id` が確定していて該当が無い場合のみ not found を表示します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)