### PR TITLE
リリース: ニュース詳細の戻る時ちらつき修正を本番反映

### DIFF
--- a/app/news/[id]/page.tsx
+++ b/app/news/[id]/page.tsx
@@ -16,13 +16,13 @@ export default function NewsDetailPage() {
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
-		const fetchNewsItem = async () => {
-			const item = getNewsById(params.id as string);
-			setNewsItem(item);
-			setIsLoading(false);
-		};
-
-		fetchNewsItem();
+		const rawId = params?.id;
+		const id = Array.isArray(rawId) ? rawId[0] : rawId;
+		// ルートパラメータが未解決（戻る操作の遷移アニメ中など）の間は状態を変えず、
+		// 直前のニュースを保持して「ニュースが見つかりません」のちらつきを防ぐ
+		if (!id) return;
+		setNewsItem(getNewsById(id));
+		setIsLoading(false);
 	}, [params.id]);
 
 	if (isLoading) {


### PR DESCRIPTION
## 概要
dev の変更を main（本番 piufolle.com）へ反映します。

## 含まれる変更
- ニュース詳細ページから戻る際に「ニュースが見つかりません」が一瞬表示される不具合を修正（id未解決の間は直前のニュースを保持）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)