### PR TITLE
リリース: 404ページの改善を本番反映（ロゴ・改行・ボタン）

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,16 +1,20 @@
 import Link from "next/link";
-import { Compass, Home, CalendarDays } from "lucide-react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 
 export default function NotFound() {
 	return (
 		// 背景・ヘッダー・フッターはルートレイアウトのものを利用
 		<div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6 pt-20 pb-16 text-center">
-			{/* アイコン */}
+			{/* Fオケのロゴ */}
 			<div className="mb-8 flex h-28 w-28 items-center justify-center rounded-full bg-white/5 ring-1 ring-white/10">
-				<Compass
-					className="h-14 w-14 text-[hsl(var(--brand))]"
-					aria-hidden="true"
+				<Image
+					src="/logo.svg"
+					alt="Orchestra più Folle"
+					width={72}
+					height={72}
+					className="h-16 w-16"
+					priority
 				/>
 			</div>
 
@@ -20,25 +24,19 @@ export default function NotFound() {
 			<h1 className="mb-4 text-2xl font-bold text-white sm:text-3xl">
 				ページが見つかりません
 			</h1>
-			<p className="mb-10 max-w-md leading-relaxed text-white/70">
-				お探しのページは移動または削除されたか、URL が間違っている可能性があります。
-				お手数ですが、以下からお戻りください。
+			<p className="mb-10 max-w-md text-pretty leading-relaxed text-white/70 [word-break:auto-phrase]">
+				お探しのページは移動または削除されたか、URL
+				が間違っている可能性があります。お手数ですが、以下からお戻りください。
 			</p>
 
 			<div className="flex w-full max-w-sm flex-col gap-3 sm:w-auto sm:flex-row">
 				<Link href="/" aria-label="ホームに戻る">
-					<Button size="lg" className="w-full gap-2 sm:w-auto">
-						<Home aria-hidden="true" />
+					<Button size="lg" className="w-full sm:w-auto">
 						ホームに戻る
 					</Button>
 				</Link>
 				<Link href="/concerts" aria-label="演奏会一覧へ">
-					<Button
-						size="lg"
-						variant="outline"
-						className="w-full gap-2 sm:w-auto"
-					>
-						<CalendarDays aria-hidden="true" />
+					<Button size="lg" variant="outline" className="w-full sm:w-auto">
 						演奏会一覧へ
 					</Button>
 				</Link>


### PR DESCRIPTION
## 概要
404(not-found)ページの改善を本番(piufolle.com)へ反映します。

- アイコンを Compass から Fオケのロゴに変更
- 説明文の不自然な改行を解消
- 2つのボタンのアイコンを削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)